### PR TITLE
make strings.Contains args order less suspicious

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -58,7 +58,7 @@ func TestGobError(t *testing.T) {
 		if err == nil {
 			t.Fatal("no error")
 		}
-		if !strings.Contains("reading body EOF", err.(error).Error()) {
+		if !strings.Contains(err.(error).Error(), "reading body EOF") {
 			t.Fatal("expected `reading body EOF', got", err)
 		}
 	}()


### PR DESCRIPTION
The old code looked suspicious and was fragile.
It would fail if error messages were not totally the same.
Swapped the arguments order to fix that.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>