### PR TITLE
Add ServeRequestContext

### DIFF
--- a/server.go
+++ b/server.go
@@ -495,7 +495,8 @@ func (server *Server) ServeConn(conn io.ReadWriteCloser) {
 // decode requests and encode responses.
 func (server *Server) ServeCodec(codec ServerCodec) {
 	sending := new(sync.Mutex)
-	pending := svc.NewPending()
+	ctx, cancel := context.WithCancel(context.Background())
+	pending := svc.NewPending(ctx)
 	wg := new(sync.WaitGroup)
 	for {
 		service, mtype, req, argv, replyv, keepReading, err := server.readRequest(codec)
@@ -504,6 +505,7 @@ func (server *Server) ServeCodec(codec ServerCodec) {
 				log.Println("rpc:", err)
 			}
 			if !keepReading {
+				cancel()
 				break
 			}
 			// send a response if we actually managed to read a header.
@@ -525,8 +527,13 @@ func (server *Server) ServeCodec(codec ServerCodec) {
 // ServeRequest is like ServeCodec but synchronously serves a single request.
 // It does not close the codec upon completion.
 func (server *Server) ServeRequest(codec ServerCodec) error {
+	return server.ServeRequestContext(context.Background(), codec)
+}
+
+// ServeRequestContext is like ServeRequest but uses the provided context.
+func (server *Server) ServeRequestContext(ctx context.Context, codec ServerCodec) error {
 	sending := new(sync.Mutex)
-	pending := svc.NewPending()
+	pending := svc.NewPending(ctx)
 	service, mtype, req, argv, replyv, keepReading, err := server.readRequest(codec)
 	if err != nil {
 		if !keepReading {
@@ -720,7 +727,11 @@ func ServeCodec(codec ServerCodec) {
 // ServeRequest is like ServeCodec but synchronously serves a single request.
 // It does not close the codec upon completion.
 func ServeRequest(codec ServerCodec) error {
-	return DefaultServer.ServeRequest(codec)
+	return ServeRequestContext(context.Background(), codec)
+}
+
+func ServeRequestContext(ctx context.Context, codec ServerCodec) error {
+	return DefaultServer.ServeRequestContext(ctx, codec)
 }
 
 // Accept accepts connections on the listener and serves requests

--- a/server_jsonrpc_test.go
+++ b/server_jsonrpc_test.go
@@ -1,0 +1,14 @@
+package rpc
+
+import (
+	"io"
+)
+
+type HTTPReadWriteCloser struct {
+	In  io.Reader
+	Out io.Writer
+}
+
+func (c *HTTPReadWriteCloser) Read(p []byte) (n int, err error)  { return c.In.Read(p) }
+func (c *HTTPReadWriteCloser) Write(d []byte) (n int, err error) { return c.Out.Write(d) }
+func (c *HTTPReadWriteCloser) Close() error                      { return nil }

--- a/server_test.go
+++ b/server_test.go
@@ -473,7 +473,7 @@ func (server *JsonServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		Out: w,
 	}
 	codec := NewJsonServerCodec(rwc)
-	server.srv.ServeCodec(codec)
+	server.srv.ServeRequestContext(req.Context(), codec)
 }
 
 func TestContextCodec(t *testing.T) {

--- a/server_util_test.go
+++ b/server_util_test.go
@@ -1,0 +1,144 @@
+// This code is all of https://golang.org/src/net/rpc/jsonrpc/server.go and some of
+// https://golang.org/src/net/rpc/jsonrpc/client.go, (both adjusted to use the fork)
+// plus some original content.
+//
+// Unfortunately but logically the net/rpc/jsonrpc uses net/rpc types which are
+// incompatible with this fork, so the code could not be used as-is.
+//
+package rpc
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"sync"
+)
+
+var errMissingParams = errors.New("jsonrpc: request body missing params")
+
+type jsonServerCodec struct {
+	dec *json.Decoder // for reading JSON values
+	enc *json.Encoder // for writing JSON values
+	c   io.Closer
+
+	// temporary work space
+	req jsonServerRequest
+
+	// JSON-RPC clients can use arbitrary json values as request IDs.
+	// Package rpc expects uint64 request IDs.
+	// We assign uint64 sequence numbers to incoming requests
+	// but save the original request ID in the pending map.
+	// When rpc responds, we use the sequence number in
+	// the response to find the original request ID.
+	mutex   sync.Mutex // protects seq, pending
+	seq     uint64
+	pending map[uint64]*json.RawMessage
+}
+
+// NewServerCodec returns a new rpc.ServerCodec using JSON-RPC on conn.
+func NewJsonServerCodec(conn io.ReadWriteCloser) ServerCodec {
+	return &jsonServerCodec{
+		dec:     json.NewDecoder(conn),
+		enc:     json.NewEncoder(conn),
+		c:       conn,
+		pending: make(map[uint64]*json.RawMessage),
+	}
+}
+
+type jsonServerRequest struct {
+	Method string           `json:"method"`
+	Params *json.RawMessage `json:"params"`
+	Id     *json.RawMessage `json:"id"`
+}
+
+func (r *jsonServerRequest) reset() {
+	r.Method = ""
+	r.Params = nil
+	r.Id = nil
+}
+
+type jsonServerResponse struct {
+	Id     *json.RawMessage `json:"id"`
+	Result interface{}      `json:"result"`
+	Error  interface{}      `json:"error"`
+}
+
+func (c *jsonServerCodec) ReadRequestHeader(r *Request) error {
+	c.req.reset()
+	if err := c.dec.Decode(&c.req); err != nil {
+		return err
+	}
+	r.ServiceMethod = c.req.Method
+
+	// JSON request id can be any JSON value;
+	// RPC package expects uint64.  Translate to
+	// internal uint64 and save JSON on the side.
+	c.mutex.Lock()
+	c.seq++
+	c.pending[c.seq] = c.req.Id
+	c.req.Id = nil
+	r.Seq = c.seq
+	c.mutex.Unlock()
+
+	return nil
+}
+
+func (c *jsonServerCodec) ReadRequestBody(x interface{}) error {
+	if x == nil {
+		return nil
+	}
+	if c.req.Params == nil {
+		return errMissingParams
+	}
+	// JSON params is array value.
+	// RPC params is struct.
+	// Unmarshal into array containing struct for now.
+	// Should think about making RPC more general.
+	var params [1]interface{}
+	params[0] = x
+	return json.Unmarshal(*c.req.Params, &params)
+}
+
+var null = json.RawMessage([]byte("null"))
+
+func (c *jsonServerCodec) WriteResponse(r *Response, x interface{}) error {
+	c.mutex.Lock()
+	b, ok := c.pending[r.Seq]
+	if !ok {
+		c.mutex.Unlock()
+		return errors.New("invalid sequence number in response")
+	}
+	delete(c.pending, r.Seq)
+	c.mutex.Unlock()
+
+	if b == nil {
+		// Invalid request so no id. Use JSON null.
+		b = &null
+	}
+	resp := jsonServerResponse{Id: b}
+	if r.Error == "" {
+		resp.Result = x
+	} else {
+		resp.Error = r.Error
+	}
+	return c.enc.Encode(resp)
+}
+
+func (c *jsonServerCodec) Close() error {
+	return c.c.Close()
+}
+
+type jsonClientRequest struct {
+	Method string         `json:"method"`
+	Params [1]interface{} `json:"params"`
+	Id     uint64         `json:"id"`
+}
+
+type HTTPReadWriteCloser struct {
+	In  io.Reader
+	Out io.Writer
+}
+
+func (c *HTTPReadWriteCloser) Read(p []byte) (n int, err error)  { return c.In.Read(p) }
+func (c *HTTPReadWriteCloser) Write(d []byte) (n int, err error) { return c.Out.Write(d) }
+func (c *HTTPReadWriteCloser) Close() error                      { return nil }

--- a/server_util_test.go
+++ b/server_util_test.go
@@ -1,9 +1,12 @@
 // This code is all of https://golang.org/src/net/rpc/jsonrpc/server.go and some of
-// https://golang.org/src/net/rpc/jsonrpc/client.go, (both adjusted to use the fork)
-// plus some original content.
+// https://golang.org/src/net/rpc/jsonrpc/client.go (both adjusted to use the fork).
 //
 // Unfortunately but logically the net/rpc/jsonrpc uses net/rpc types which are
 // incompatible with this fork, so the code could not be used as-is.
+//
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 //
 package rpc
 
@@ -133,12 +136,3 @@ type jsonClientRequest struct {
 	Params [1]interface{} `json:"params"`
 	Id     uint64         `json:"id"`
 }
-
-type HTTPReadWriteCloser struct {
-	In  io.Reader
-	Out io.Writer
-}
-
-func (c *HTTPReadWriteCloser) Read(p []byte) (n int, err error)  { return c.In.Read(p) }
-func (c *HTTPReadWriteCloser) Write(d []byte) (n int, err error) { return c.Out.Write(d) }
-func (c *HTTPReadWriteCloser) Close() error                      { return nil }


### PR DESCRIPTION
This PR adds the ability to do `rpcServer.ServeRequestContext(ctx, codec)`

This is useful for wiring up RPC when you don't have a TCP connection or are unable to hijack HTTP, but still want cancellation.

See the test for an example of how it could be used.

Closes #3 